### PR TITLE
fix java IDE dependency

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="IdProvider" IDEtalkID="BA0398FD00345247FD64E3DED25981B9" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_3" default="false" project-jdk-name="IntelliJ IDEA IU-181.4668.68" project-jdk-type="IDEA JDK">
+  <component name="NullableNotNullManager">
+    <option name="myNullables">
+      <value>
+        <list size="9">
+          <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
+          <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
+          <item index="2" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
+          <item index="3" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
+          <item index="4" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
+          <item index="5" class="java.lang.String" itemvalue="androidx.annotation.Nullable" />
+          <item index="6" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
+          <item index="7" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
+          <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
+        </list>
+      </value>
+    </option>
+    <option name="myNotNulls">
+      <value>
+        <list size="9">
+          <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
+          <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
+          <item index="2" class="java.lang.String" itemvalue="javax.validation.constraints.NotNull" />
+          <item index="3" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
+          <item index="4" class="java.lang.String" itemvalue="android.support.annotation.NonNull" />
+          <item index="5" class="java.lang.String" itemvalue="androidx.annotation.NonNull" />
+          <item index="6" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
+          <item index="7" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
+          <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
+        </list>
+      </value>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="IDEA plugin jdk" project-jdk-type="IDEA JDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.lid.intellij.translateme</id>
     <name>TranslateMe</name>
-    <version>1.0.0.5</version>
+    <version>1.0.0.7</version>
     <vendor email="vladimir.vs.ivanov@gmail.com" url="https://github.com/vlivanov">vlivanov's GitHub</vendor>
 
     <description><![CDATA[
@@ -14,6 +14,7 @@
     ]]></description>
 
     <change-notes><![CDATA[
+            1.0.0.7 Fix dependency on Java IDE only classes
             1.0.0.6 Settings are saved across IDE restart<br>
             1.0.0.5 Fix saving settings; add 2017.1 compatibility<br>
             1.0.0.4 Restore settings<br>
@@ -33,9 +34,7 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <!-- Add your extensions here -->
-        <applicationConfigurable instance="com.lid.intellij.translateme.configuration.ConfigurationComponent">
-
-        </applicationConfigurable>
+        <applicationConfigurable instance="com.lid.intellij.translateme.configuration.ConfigurationComponent"/>
     </extensions>
 
     <application-components>
@@ -44,14 +43,6 @@
             <interface-class>com.lid.intellij.translateme.configuration.PersistingService</interface-class>
         </component>
     </application-components>
-
-    <project-components>
-        <component>
-            <interface-class>com.lid.intellij.translateme.configuration.ConfigurationComponent</interface-class>
-            <implementation-class>com.lid.intellij.translateme.configuration.ConfigurationComponent</implementation-class>
-            <option value="true" name="workspace"/>
-        </component>
-    </project-components>
 
     <actions>
         <!-- Add your actions here -->

--- a/TranslateMe.iml
+++ b/TranslateMe.iml
@@ -8,5 +8,6 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="gson-2.8.4" level="project" />
   </component>
 </module>

--- a/src/com/lid/intellij/translateme/actions/TranslateAction.java
+++ b/src/com/lid/intellij/translateme/actions/TranslateAction.java
@@ -1,78 +1,125 @@
 package com.lid.intellij.translateme.actions;
 
+import com.intellij.codeInsight.hint.HintManager;
+import com.intellij.codeInsight.hint.HintManagerImpl;
+import com.intellij.codeInsight.hint.HintUtil;
+import com.intellij.ide.BrowserUtil;
+import com.intellij.notification.NotificationDisplayType;
+import com.intellij.notification.NotificationGroup;
+import com.intellij.notification.NotificationType;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.editor.CaretModel;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.VisualPosition;
 import com.intellij.openapi.editor.actionSystem.EditorAction;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.MessageType;
-import com.intellij.openapi.ui.popup.Balloon;
-import com.intellij.openapi.ui.popup.BalloonBuilder;
-import com.intellij.openapi.ui.popup.JBPopupFactory;
-import com.intellij.ui.awt.RelativePoint;
+import com.intellij.ui.LightweightHint;
+import com.intellij.xml.util.XmlStringUtil;
 import com.lid.intellij.translateme.ResultDialog;
 import com.lid.intellij.translateme.configuration.ConfigurationState;
 import com.lid.intellij.translateme.configuration.PersistingService;
 
-import java.awt.*;
+import javax.swing.JComponent;
+import javax.swing.event.HyperlinkEvent;
+import java.awt.Point;
 import java.util.List;
 
+import static javax.swing.event.HyperlinkEvent.EventType.ACTIVATED;
+
 public class TranslateAction extends EditorAction {
+    static final NotificationGroup NOTIFICATION_GROUP = new NotificationGroup("TranslateMe Alerts", NotificationDisplayType.STICKY_BALLOON, false, null);
 
-	public TranslateAction() {
-		super(new TranslateHandler(new PopupActionHandler()));
-	}
+    public TranslateAction() {
+        super(new TranslateHandler(new PopupActionHandler()));
+    }
 
-	public static String[] getLangPair(Project project) {
+    public static String[] getLangPair() {
+        ConfigurationState state = PersistingService.getInstance().getState();
 
-		if (project != null) {
-			ConfigurationState state = PersistingService.getInstance(project).getState();
+        String from = state.getLangFrom();
+        String to = state.getLangTo();
+        return new String[] { from, to };
+    }
 
-			String from = state.getLangFrom();
-			String to = state.getLangTo();
-			return new String[]{from, to};
-		}
+    public static boolean isAutoDetect() {
+        ConfigurationState state = PersistingService.getInstance().getState();
+        return state.isAutoDetect();
+    }
 
-		return new String[]{"en", "ru"};
-	}
+    public static boolean isTranslationTooltip() {
+        ConfigurationState state = PersistingService.getInstance().getState();
+        return state.isTranslationTooltip();
+    }
 
-	public static boolean isAutoDetect(Project project) {
-		if (project != null) {
-			ConfigurationState state = PersistingService.getInstance(project).getState();
-			return state.isAutoDetect();
-		}
-
-		return false;
-	}
-
-	private static class PopupActionHandler implements ActionHandler {
-		@Override
-		public void handleResult(Editor editor, List<String> translated) {
-			Application app = ApplicationManager.getApplication();
-			app.invokeLater(() -> {
-                ResultDialog resultDialog = new ResultDialog("Translated", translated);
-                resultDialog.setVisible(true);
+    private static class PopupActionHandler implements ActionHandler {
+        @Override
+        public void handleResult(Editor editor, List<String> translated) {
+            Application app = ApplicationManager.getApplication();
+            app.invokeLater(() -> {
+                if (isTranslationTooltip()) {
+                    StringBuilder sb = new StringBuilder();
+                    int iMax = translated.size();
+                    String sep = "";
+                    for (int i = 0; i < iMax; i++) {
+                        sb.append(sep).append(translated.get(i));
+                        sep = "\n";
+                    }
+                    sb.append("<p><a href='http://translate.yandex.com/'>Powered by Yandex.Translator</a>");
+                    showTooltip(editor, sb.toString());
+                } else {
+                    ResultDialog resultDialog = new ResultDialog("Translated", translated);
+                    resultDialog.setVisible(true);
+                }
             });
-		}
+        }
 
-		@Override
-		public void handleError(Editor editor) {
-			Application app = ApplicationManager.getApplication();
-			app.invokeLater(() -> {
-				showErrorBallon(editor, "Failed to translate");
-			});
-		}
+        @Override
+        public void handleError(Editor editor) {
+            Application app = ApplicationManager.getApplication();
+            app.invokeLater(() -> {
+                showErrorBalloon(editor, "Failed to translate");
+            });
+        }
 
-		private void showErrorBallon(Editor editor, String message) {
-			BalloonBuilder builder =
-					JBPopupFactory.getInstance().createHtmlTextBalloonBuilder("hello", MessageType.ERROR, null);
-			Balloon balloon = builder.createBalloon();
-			balloon.setTitle(message);
-			CaretModel caretModel = editor.getCaretModel();
-			Point point = editor.visualPositionToXY(caretModel.getVisualPosition());
-			RelativePoint where = new RelativePoint(point);
-			balloon.show(where, Balloon.Position.below);
-		}
-	}
+        private void showErrorBalloon(Editor editor, String message) {
+            NOTIFICATION_GROUP.createNotification("TranslateMe Error", XmlStringUtil.wrapInHtml(message), NotificationType.ERROR, (notification, event) -> {
+            }).notify(null);
+        }
+
+        private void showTooltip(Editor editor, String message) {
+            //String text = "<table><tr><td>&nbsp;</td><td>$message</td><td>&nbsp;</td></tr></table>"
+            HintManagerImpl hintManager = (HintManagerImpl) HintManager.getInstance();
+            int flags = HintManager.HIDE_BY_CARET_MOVE | HintManager.UPDATE_BY_SCROLLING | HintManager.HIDE_BY_ESCAPE;
+            int timeout = 60000; // default 1min?
+            String html = HintUtil.prepareHintText(message, HintUtil.getInformationHint());
+
+            JComponent label = HintUtil.createInformationLabel(html, e -> {
+                if (e.getEventType() == ACTIVATED) {
+                    BrowserUtil.browse("http://translate.yandex.com/");
+                }
+            }, null, null);
+
+            LightweightHint hint = new LightweightHint(label);
+
+            VisualPosition start = editor.offsetToVisualPosition(editor.getSelectionModel().getSelectionStart());
+            VisualPosition end = editor.offsetToVisualPosition(editor.getSelectionModel().getSelectionEnd());
+
+            CharSequence chars = editor.getDocument().getCharsSequence();
+            int i = editor.getSelectionModel().getSelectionStart();
+            int iMax = editor.getSelectionModel().getSelectionEnd();
+            int maxColumn = Math.max(start.column,end.column);
+            for (; i < iMax; ++i) {
+                if (i > 0 && chars.charAt(i) == '\n') {
+                    VisualPosition vis = editor.offsetToVisualPosition(i - 1);
+                    if (maxColumn < vis.column) {
+                        maxColumn = vis.column;
+                    }
+                }
+            }
+
+            VisualPosition pos = new VisualPosition(start.line, (start.column + maxColumn) / 2, false);
+
+            Point p = hintManager.getHintPosition(hint, editor, pos, HintManager.ABOVE);
+            hintManager.showEditorHint(hint, editor, p, flags, timeout, false);
+        }
+    }
 }

--- a/src/com/lid/intellij/translateme/actions/TranslateHandler.java
+++ b/src/com/lid/intellij/translateme/actions/TranslateHandler.java
@@ -31,8 +31,8 @@ class TranslateHandler extends EditorWriteActionHandler {
 			String splittedText = splitCamelCase(selectedText);
 			splittedText = splitUnderscore(splittedText);
 
-			String[] langPairs = TranslateAction.getLangPair(project);
-			boolean autoDetect = TranslateAction.isAutoDetect(project);
+			String[] langPairs = TranslateAction.getLangPair();
+			boolean autoDetect = TranslateAction.isAutoDetect();
 			List<String> translated = new YandexTranslator().translate(splittedText, langPairs, autoDetect);
 			if (translated != null) {
 				mHandler.handleResult(editor, translated);

--- a/src/com/lid/intellij/translateme/configuration/ConfigurationComponent.java
+++ b/src/com/lid/intellij/translateme/configuration/ConfigurationComponent.java
@@ -3,23 +3,23 @@ package com.lid.intellij.translateme.configuration;
 import com.intellij.openapi.components.ProjectComponent;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.options.ConfigurationException;
-import com.intellij.projectImport.ProjectImportBuilder;
+import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 
-public final class ConfigurationComponent implements ProjectComponent, Configurable {
+public final class ConfigurationComponent implements Configurable {
 	public static final String COMPONENT_NAME = "Translate.ConfigurationComponent";
 //  private final ImageIcon CONFIG_ICON =
 //          helper.getIcon("resources/icon.png", getClass());
 
-	public static final String CONFIGURATION_LOCATION;
+	//public static final String CONFIGURATION_LOCATION;
 	//+"/.IntelliJIdea70/config/inspection";
 
-	static {
-		CONFIGURATION_LOCATION = System.getProperty("user.home");
-		//+"/.IntelliJIdea70/config/inspection";
-	}
+	//static {
+	//	CONFIGURATION_LOCATION = System.getProperty("user.home");
+	//	//+"/.IntelliJIdea70/config/inspection";
+	//}
 
 	private TranslationConfigurationForm form;
 	private PersistingService instance;
@@ -29,15 +29,6 @@ public final class ConfigurationComponent implements ProjectComponent, Configura
 		return form != null && form.isModified(getState());
 	}
 
-	@Override
-	public void projectOpened() {
-		System.out.println("ConfigurationComponent.projectOpened");
-	}
-
-	@Override
-	public void projectClosed() {
-		System.out.println("ConfigurationComponent.projectClosed");
-	}
 
 	private ConfigurationState getState() {
 		return instance.getState();
@@ -46,14 +37,6 @@ public final class ConfigurationComponent implements ProjectComponent, Configura
 	@NotNull
 	public String getComponentName() {
 		return COMPONENT_NAME;
-	}
-
-	@Override
-	public void initComponent() {
-	}
-
-	@Override
-	public void disposeComponent() {
 	}
 
 	@Override
@@ -76,7 +59,7 @@ public final class ConfigurationComponent implements ProjectComponent, Configura
 		if (form == null) {
 			form = new TranslationConfigurationForm();
 		}
-		instance = PersistingService.getInstance(ProjectImportBuilder.getCurrentProject());
+		instance = PersistingService.getInstance();
 		ConfigurationState state = instance.getState();
 		form.load(state);
 

--- a/src/com/lid/intellij/translateme/configuration/ConfigurationState.java
+++ b/src/com/lid/intellij/translateme/configuration/ConfigurationState.java
@@ -5,6 +5,7 @@ public class ConfigurationState {
 	private String langFrom = "en";
 	private String langTo = "ru";
 	private boolean autoDetect = false;
+	private boolean translationTooltip = false;
 
 	public String getLangFrom() {
 		return langFrom;
@@ -35,5 +36,13 @@ public class ConfigurationState {
 	public void setLangPair(final String from, final String to) {
 		langFrom = from;
 		langTo = to;
+	}
+
+	public boolean isTranslationTooltip() {
+		return translationTooltip;
+	}
+
+	public void setTranslationTooltip(final boolean translationTooltip) {
+		this.translationTooltip = translationTooltip;
 	}
 }

--- a/src/com/lid/intellij/translateme/configuration/PersistingService.java
+++ b/src/com/lid/intellij/translateme/configuration/PersistingService.java
@@ -12,11 +12,10 @@ import org.jetbrains.annotations.Nullable;
 	storages = @Storage("translateMe.xml")
 )
 public class PersistingService implements PersistentStateComponent<ConfigurationState> {
-
 	private ConfigurationState state;
 
-	public static PersistingService getInstance(Project project) 	{
-		return ServiceManager.getService(project, PersistingService.class);
+	public static PersistingService getInstance() 	{
+		return ServiceManager.getService(PersistingService.class);
 	}
 
 	@Nullable

--- a/src/com/lid/intellij/translateme/configuration/TranslationConfigurationForm.java
+++ b/src/com/lid/intellij/translateme/configuration/TranslationConfigurationForm.java
@@ -21,6 +21,7 @@ public class TranslationConfigurationForm {
 
 	private LangsResponse mLangsResponse;
 	private final Checkbox autoDetect;
+	private final Checkbox translationTooltip;
 
 	public TranslationConfigurationForm() {
 		rootComponent = new JPanel();
@@ -43,9 +44,17 @@ public class TranslationConfigurationForm {
 		c2.gridx= 0;
 		c2.gridy = 1;
 		autoDetect = new Checkbox("Auto-detect");
-
 		initCheckbox(autoDetect);
 		rootComponent.add(autoDetect, c2);
+
+		GridBagConstraints c3 = new GridBagConstraints();
+		c.anchor = GridBagConstraints.EAST;
+		c3.fill = GridBagConstraints.EAST;
+		c3.gridx= 0;
+		c3.gridy = 2;
+		translationTooltip = new Checkbox("Use tooltip to display translations");
+		rootComponent.add(translationTooltip, c3);
+
 	}
 
 	@NotNull
@@ -112,6 +121,7 @@ public class TranslationConfigurationForm {
 		}
 
 		data.setAutoDetect(autoDetect.getState());
+		data.setTranslationTooltip(translationTooltip.getState());
 		return;
 	}
 
@@ -119,6 +129,7 @@ public class TranslationConfigurationForm {
 		comboBoxFrom.setSelectedItem(data.getLangFrom());
 		comboBoxTo.setSelectedItem(data.getLangTo());
 		autoDetect.setState(data.isAutoDetect());
+		translationTooltip.setState(data.isTranslationTooltip());
 		return true;
 	}
 
@@ -131,8 +142,9 @@ public class TranslationConfigurationForm {
 		final boolean fromChanged = selectedFrom != null && !selectedFrom.equals(data.getLangFrom());
 		final boolean toChanged = selectedTo != null && !selectedTo.equals(data.getLangTo());
 		final boolean detectChanged = autoChecked != data.isAutoDetect();
+		final boolean balloonChanged = translationTooltip.getState() != data.isTranslationTooltip();
 
-		return fromChanged || toChanged || detectChanged;
+		return fromChanged || toChanged || detectChanged || balloonChanged;
 	}
 
 }

--- a/src/com/lid/intellij/translateme/translators/YandexTranslator.java
+++ b/src/com/lid/intellij/translateme/translators/YandexTranslator.java
@@ -22,8 +22,7 @@ public class YandexTranslator implements Translator {
 		if (autoDetect) {
 			String detect = yandexClient.detect(splittedText, langPairs[0], langPairs[1]);
 			DetectLanguageResponse response = new Gson().fromJson(detect, DetectLanguageResponse.class);
-			int code = response.getCode();
-			if (code == 200) {
+			if (response != null && response.getCode() == 200) {
 				String language = response.getLang();
 				translated = yandexClient.translate(splittedText, language, langPairs[1]);
 			} else {


### PR DESCRIPTION
Great plugin.

I needed these changes ASAP. I have German Spec Docs in a WebStorm project, lots of German comments in the code and I don't speak German. 

The tooltip option shows translations in a tooltip to make translations not get in the way like the dialog does. You may want to add a timeout option in settings. I set to 60 seconds but moving caret or hitting escape will close it early.

This also fixes #10, I reported earlier.

* remove need for project from configuration state instance
* add show translations as tooltip
* fix NPE if auto detection fails and returns null
* add notification balloon group to allow user configuration